### PR TITLE
feat: add support for erc20-balance-of-weighted and erc20-balance-of-coeff strategy

### DIFF
--- a/src/strategies/erc20-balance-of-weighted.ts
+++ b/src/strategies/erc20-balance-of-weighted.ts
@@ -6,5 +6,8 @@ export default async function getValue(
   network: number,
   snapshot: number
 ): Promise<number> {
-  return (await erc20BalanceOf(params, network, snapshot)) / params.weight;
+  return (
+    (await erc20BalanceOf(params, network, snapshot)) /
+    (params.weight ?? params.coeff)
+  );
 }

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -31,6 +31,7 @@ const strategies: Record<string, StrategyFunction> = {
   'erc20-balance-of-delegation': erc20BalanceOf,
   'erc20-balance-of-with-delegation': erc20BalanceOf,
   'erc20-balance-of-weighted': erc20BalanceOfWeighted,
+  'erc20-balance-of-coeff': erc20BalanceOfWeighted,
   'erc20-votes': erc20BalanceOf,
   'erc20-votes-with-override': erc20BalanceOf,
   'comp-like-votes': erc20BalanceOf,


### PR DESCRIPTION
This PR will add support for the `erc20-balance-of-weighted` and `erc20-balance-of-coeff` strategies

This strategy is used on 63+43 pro proposals, spread on 4 spaces