### PR TITLE
feat: add support for pagination strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,5 +1,6 @@
 import erc20BalanceOf from './erc20-balance-of';
 import multichain from './multichain';
+import pagination from './pagination';
 import uni from './uni';
 
 export interface StrategyParams {
@@ -34,6 +35,7 @@ const strategies: Record<string, StrategyFunction> = {
   'comp-like-votes': erc20BalanceOf,
   uni,
   multichain,
+  pagination,
   delegation: multichain,
   'with-delegation': multichain
 };

--- a/src/strategies/pagination.ts
+++ b/src/strategies/pagination.ts
@@ -1,0 +1,11 @@
+import getStrategiesValue from './index';
+
+export default async function getValue(
+  params: any,
+  network: number,
+  snapshot: number
+): Promise<number> {
+  if (!params.strategy) return 0;
+
+  return (await getStrategiesValue(network, snapshot, [params.strategy]))[0];
+}

--- a/test/__snapshots__/strategies.test.ts.snap
+++ b/test/__snapshots__/strategies.test.ts.snap
@@ -25,6 +25,12 @@ exports[`Strategies should execute multiple strategies 1`] = `
 ]
 `;
 
+exports[`Strategies should execute pagination strategy with specific parameters 1`] = `
+[
+  17.25638653634901,
+]
+`;
+
 exports[`Strategies should handle 0 decimals parameter correctly 1`] = `
 [
   0.000001003258127454142,

--- a/test/strategies.test.ts
+++ b/test/strategies.test.ts
@@ -29,6 +29,25 @@ describe('Strategies', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should execute pagination strategy with specific parameters', async () => {
+    const result = await getStrategiesValue(1, 1640998800, [
+      {
+        name: 'pagination',
+        network: 1,
+        params: {
+          strategy: {
+            name: 'erc20-balance-of',
+            params: {
+              address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+              decimals: 18
+            }
+          }
+        }
+      }
+    ]);
+    expect(result).toMatchSnapshot();
+  });
+
   it('should convert price when param decimals differ from token decimals', async () => {
     const result = await getStrategiesValue(8453, 1640998800, [
       {


### PR DESCRIPTION
Add support for the `pagination` strategy (https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/pagination)

This essentially just call the inner strategy defined in `params.strategy`