### PR TITLE
fix: bump coingecko search range, for token without much activities

### DIFF
--- a/src/helpers/coingecko.ts
+++ b/src/helpers/coingecko.ts
@@ -1,7 +1,7 @@
 import { withCache } from './cache';
 
 const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY || '';
-const TIME_WINDOW = 1800;
+const TIME_WINDOW = 2 * 3600;
 const BASE_URL = 'https://pro-api.coingecko.com/api/v3';
 const CURRENCY = 'usd';
 


### PR DESCRIPTION
For some tokens without much activities, the coingecko range query may return empty results.

This PR is bumping the search range from 30 minutes to 2 hours, to increase the possibility of having some results