### PR TITLE
fix: handle missing params object

### DIFF
--- a/src/strategies/eth-balance.ts
+++ b/src/strategies/eth-balance.ts
@@ -8,7 +8,7 @@ export default async function getValue(
   network: number,
   snapshot: number
 ): Promise<number> {
-  const decimals = params.decimals ?? DEFAULT_DECIMAL;
+  const decimals = params?.decimals ?? DEFAULT_DECIMAL;
   const price = await getTokenPriceAtTimestamp(network, null, snapshot);
 
   return price / Math.pow(10, DEFAULT_DECIMAL - decimals);


### PR DESCRIPTION
This PR fix an issue, when the "delegation" strategy does not have a params object.

There are 6 proposals which were omitting it.

## Test

The following request should not crash anymore

```
curl -s http://localhost:3000 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"get_value_by_strategy","params":{"network":"1","strategies":[{"name":"eth-balance","params":{"symbol":"ETH"}},{"name":"delegation","params":{"symbol":"ETH (delegated)","strategies":[{"name":"eth-balance"}]}}],"snapshot":1641096000},"id":1}'
```