### PR TITLE
fix: handle NaN in erc20-balance-of-weighted when weight/coeff is missing

### DIFF
--- a/src/strategies/erc20-balance-of-weighted.ts
+++ b/src/strategies/erc20-balance-of-weighted.ts
@@ -9,5 +9,5 @@ export default async function getValue(
   const value =
     (await erc20BalanceOf(params, network, snapshot)) /
     (params.weight ?? params.coeff);
-  return Number.isNaN(value) ? 0 : value;
+  return Number.isFinite(value) ? value : 0;
 }

--- a/src/strategies/erc20-balance-of-weighted.ts
+++ b/src/strategies/erc20-balance-of-weighted.ts
@@ -6,8 +6,8 @@ export default async function getValue(
   network: number,
   snapshot: number
 ): Promise<number> {
-  return (
+  const value =
     (await erc20BalanceOf(params, network, snapshot)) /
-    (params.weight ?? params.coeff)
-  );
+    (params.weight ?? params.coeff);
+  return Number.isNaN(value) ? 0 : value;
 }

--- a/src/strategies/eth-balance.ts
+++ b/src/strategies/eth-balance.ts
@@ -8,7 +8,7 @@ export default async function getValue(
   network: number,
   snapshot: number
 ): Promise<number> {
-  const decimals = params.decimals ?? DEFAULT_DECIMAL;
+  const decimals = params?.decimals ?? DEFAULT_DECIMAL;
   const price = await getTokenPriceAtTimestamp(network, null, snapshot);
 
   return price / Math.pow(10, DEFAULT_DECIMAL - decimals);

--- a/test/strategies/erc20-balance-of-weighted.test.ts
+++ b/test/strategies/erc20-balance-of-weighted.test.ts
@@ -1,0 +1,44 @@
+import getValue from '../../src/strategies/erc20-balance-of-weighted';
+
+jest.mock('../../src/strategies/erc20-balance-of', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(100)
+}));
+
+describe('erc20-balance-of-weighted strategy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should divide price by weight', async () => {
+    const result = await getValue(
+      { address: '0x123', weight: 0.5 } as any,
+      1,
+      1640998800
+    );
+    expect(result).toBe(200);
+  });
+
+  it('should divide price by coeff when weight is missing', async () => {
+    const result = await getValue(
+      { address: '0x123', coeff: 2 } as any,
+      1,
+      1640998800
+    );
+    expect(result).toBe(50);
+  });
+
+  it('should return 0 when weight and coeff are missing', async () => {
+    const result = await getValue({ address: '0x123' } as any, 1, 1640998800);
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 when weight is 0', async () => {
+    const result = await getValue(
+      { address: '0x123', weight: 0 } as any,
+      1,
+      1640998800
+    );
+    expect(result).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`erc20-balance-of-weighted` returns `null` instead of a number when the `weight` or `coeff` param is missing. Dividing by `undefined` produces `NaN`, which gets serialized as `null` in the JSON-RPC response.

As a by-product, the sequencer marks proposals using this strategy as `ERROR_SYNC` (since the response contains `null` instead of a valid number), causing them and their votes to get stuck permanently.

### Affected proposal

- `0xc72697663374baa9b8e25e9101fa021ee63ee2eb1e662bce9030c17069125ac6` (nikar0.eth, Fantom) — 22 stuck votes

### score-api equivalent

In score-api, the [`erc20-balance-of-weighted` strategy](https://github.com/snapshot-labs/score-api/blob/master/src/strategies/strategies/erc20-balance-of-weighted/index.ts) also produces `NaN` when weight is missing (`score * options.weight`), but downstream consumers silently skip `NaN` values via truthiness checks (`y[b] ? x + y[b] : x`), so scoring still succeeds.

This fix returns `0` when the result is `NaN`, matching the effective score-api behavior.

## Changes

- 🐛 Return `0` instead of `NaN` in `erc20-balance-of-weighted` when `weight`/`coeff` param is missing

## Test plan

```bash
curl -s -X POST https://overlord.snapshot.box \
  -H 'Content-Type: application/json' \
  -d '{
    "jsonrpc": "2.0",
    "method": "get_value_by_strategy",
    "params": {
      "network": "250",
      "strategies": [{"name": "erc20-balance-of-weighted", "params": {"symbol": "g-1-EVO-FTM", "address": "0xD2752EB1794C4a1b7891feF1e1376B9C9c2FB2DA", "decimals": 18}, "network": "250"}],
      "snapshot": 1648586030
    },
    "id": 1
  }'
```

**Before:** `{"result": [null]}`
**Expected after:** `{"result": [0]}`