### PR TITLE
fix: return 0 when contract doesn't implement decimals()

### DIFF
--- a/src/strategies/erc20-balance-of.ts
+++ b/src/strategies/erc20-balance-of.ts
@@ -93,10 +93,17 @@ export default async function getValue(
     return 0;
   }
 
-  const tokenDecimals = await getTokenDecimals(
-    Number(tokenNetwork),
-    tokenAddress
-  );
+  let tokenDecimals: number;
+  try {
+    tokenDecimals = await getTokenDecimals(Number(tokenNetwork), tokenAddress);
+  } catch (e: any) {
+    // CALL_EXCEPTION means the contract doesn't implement decimals()
+    // Other errors (timeout, network) are temporary and should be retried
+    if (e.code === 'CALL_EXCEPTION') {
+      return 0;
+    }
+    throw e;
+  }
 
   return price / Math.pow(10, tokenDecimals - decimals);
 }


### PR DESCRIPTION
## Summary

Partially fix https://snapshot-labs.sentry.io/issues/7328652620/?project=4505606761152512&query=is%3Aunresolved&referrer=issue-stream

When a token contract doesn't implement `decimals()`, the `erc20-balance-of` strategy throws an unhandled error that bubbles up as a 500. The sequencer marks the proposal as `ERROR_SYNC` and retries indefinitely — generating ~36K Sentry errors ([SNAPSHOT-SEQUENCER-48](https://snapshot-labs.sentry.io/issues/7328652620/)) since March 12.

The fix catches `CALL_EXCEPTION` errors (ethers.js error code for contract reverts) and returns `0` USD value — same as when CoinGecko has no price data. Temporary errors (timeout, network) are re-thrown so the sequencer can retry.

## Changes

- 🐛 Catch `CALL_EXCEPTION` in `erc20-balance-of` strategy and return 0
- 🔄 Re-throw other errors (timeout, network) to allow retries

## Test plan

- [ ] Verify overlord no longer returns 500 for contracts missing `decimals()` (e.g. SENSO `0xC19B6A4Ac7C7Cc24459F08984Bbd09664af17bD1` on mainnet)
- [ ] Verify temporary RPC errors still return 500 so sequencer retries
- [ ] Verify normal tokens with `decimals()` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)